### PR TITLE
Fix memory leaks and add more methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ int main(int argc, char* argv[]){
 
   /* Exit method suspends the existing event queue thread
     flushes all the events and event datas that are queued
+    event-man instance becomes useless after the exit call and
+    will throw error
 
     man->Exit();
     delete man;
@@ -39,6 +41,12 @@ Handle listener(Handle event, Handle data){
 }
 ```
 ## API
+```c++ 
+bool EventMan.isAlive()
+```
+Returns the current state of the event queue, if false than the queue will throw error for any operation
+
+
 ```c++ 
 void EventMan.Push(string name, &handler)
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-__This is a fun project not for prod usage, many things need to be fixed in it.__
 # E2
 Create as many event loops you want, pass the loops to different network/fs/timer interrupt locked threads.
 ```c++
@@ -8,25 +7,95 @@ using namespace E2;
 Handle listener(Handle, Handle);
 
 int main(int argc, char* argv[]){
-	E2::EventMan *man; // you can share this instance with other threads
-	man = new E2::EventMan();
-	std::string eName("push");
-	man->Listen(&eName, &listener);
-	man->Trigger(&eName, nil); // 2nd argument is for data
-	// call all fs/net and other threads before this
-	// this is the end marker which will block the code
+  E2::EventMan *man; // you can share this instance with other threads
+  man = new E2::EventMan();
+  man->Listen("push", &listener);
+  man->Trigger("push", nil); // 2nd argument is for data
+  Handle *data = new int(0x0fff);
+  man->Trigger("push", data)
+  // call all fs/net and other threads before this
+  // this is the end marker which will block the code
   // you can create more EventMan and then wait for all of them
-	man->Join();
-	return 0;
+
+  /* Exit method suspends the existing event queue thread
+    flushes all the events and event datas that are queued
+
+    man->Exit();
+    delete man;
+  */
+  man->Join();
+  return 0;
 }
 
 Handle listener(Handle event, Handle data){
-	E2::EventData *e = (E2::EventData *)event;
-	cout << "Event Triggered" << std::endl;
-	cout << "Event name=> " << *(e->name) << std::endl;
-	return nil;
+  E2::EventData *e = (E2::EventData *)event;
+  cout << "Event Triggered" << std::endl;
+  cout << "Event name=> " << *(e->name) << std::endl;
+  if (data != nil){
+    cout << "The passed integer is: " << *((int*)data);
+  }
+  clear_e2_event(e); // a helper to clear event data
+  return nil;
 }
 ```
-##ToDo
-- Share a common semaphore to wait for all the eventMan to end and terminate all of them.
+## API
+```c++ 
+void EventMan.Push(string name, &handler)
+```
+
+Pushes a new event handler for an event, the handler parameter is a function pointer which should be of the below signature 
+```c++
+Handle func_name(Handle, Handle)
+```
+
+
+```c++
+int EventMan.Trigger(string name, Handle data)
+```
+Triggers all the event listeners of a specific event and passes the data to the handlers, if no such event exists than its a noop(). The function returns the number of listeners triggered
+
+
+```c++ 
+void EventMan.Join(void)
+```
+
+Locks the Spinlock thread and waits for its completion.
+
+
+```c++ 
+void EventMan.Exit(void)
+```
+Kills the Spinlock thread. Call ```delete EventMan;``` manually after this to free its memory. You can use this to trigger the end of event loop manually.
+
+### Listeners Helpers
+The library by default doesn't clear the parameters passed to the listeners, its upto the users to clear the memory.
+```c++
+clear_e2_event(event)
+```
+
+Use this to clear the complete event struct passed to your event listener.
+```c++
+Handle file_read_listener(Handle event, Handle data) {
+  E2::EventData *eData = (E2::EventData*)event;
+  /* do something with eData and data */
+  clear_e2_event(e)
+}
+```
+
+```c++ 
+clear_e2_event_name(event)
+```
+
+Use this to clear the std::string event name if you are going to use the data pointer, this is not done by the library automatically
+```c++
+Handle file_read_listener(Handle event, Handle data) {
+  E2::EventData *eData = (E2::EventData*)event;
+  /* do something with eData and data */
+  clear_e2_event_name(e)
+}
+```
+
+__Note__: Call atleast one helper from the above to clear unused memory.
+
+## ToDo
 - Provide ```net/fs/time``` library helpers

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 /*
-
-	Pseudo Events lib C++
+  A Spinlock based Event queue implementation
 */
 
 #include <iostream>
@@ -11,71 +10,140 @@ using namespace E2;
 using namespace std;
 
 EventMan::EventMan(){
-	this->initQueue();
+  this->initQueue();
 }
 
 Handle EventMan::initQueue(){
-	this->event_queue = new EventQueue();
-	return nil;
-}
-Handle EventMan::Join(){
-	this->event_queue->join();
-	return nil;
-}
-Handle EventMan::Listen(Handle event_name, EventCallbackHandle listener){
-	std::string *name  = (std::string *) event_name;
-	auto hasEvent = this->event_map[*name];
-	if (hasEvent == nil){
-		// event doesn't exists
-		std::vector<EventCallbackHandle> *vec = new std::vector<EventCallbackHandle>();
-		this->event_map[*name] = vec;
-	}
-	this->event_map[*name]->push_back(listener);
-	return nil;
+  this->event_queue = new EventQueue();
+  return nil;
 }
 
-Handle EventMan::Trigger(Handle event_name, EventData *data){
-	auto name = (std::string *) event_name;
-	auto listeners = *(this->event_map[*name]);
-	for(auto el : listeners){
-		auto e = new EventData();
-		e->name = name;
-		e->callback = el;
-		e->data = nil;
-		this->event_queue->push(e);
-	}
-	return this->event_map[*name];
+void EventMan::Join(){
+  this->event_queue->join();
+}
+
+void EventMan::Listen(std::string event_name, EventCallbackHandle listener){
+  auto hasEvent = this->event_map[event_name];
+  if (hasEvent == nil){
+    /* event doesn't exists */
+    std::vector<EventCallbackHandle> *vec = new std::vector<EventCallbackHandle>();
+    this->event_map[event_name] = vec;
+  }
+  this->event_map[event_name]->push_back(listener);
+}
+
+int EventMan::Trigger(std::string event_name, Handle *data){
+  if (this->event_map[event_name] == nil){
+    this->event_map.erase(event_name);
+    return 0;
+  }
+  auto listeners = *(this->event_map[event_name]);
+  for(auto el : listeners){
+    auto e = new EventData();
+    e->name = new std::string(event_name);
+    e->callback = el;
+    e->data = data;
+    this->event_queue->push(e);
+  }
+  return this->event_map[event_name]->size();
+}
+
+void EventMan::Exit(){
+  if (!this->event_queue->isClosed()){
+    delete this->event_queue;
+    this->event_queue = nil;
+  }
+}
+EventMan::~EventMan(){
+  if (this->event_queue != nil){
+    delete this->event_queue;
+  }
+  if (this->event_map.empty() == false){
+    this->event_map.clear();
+  }
 }
 
 EventQueue::EventQueue(){
-	this->events = *(new std::vector<EventData*>());
-	this->thread = new std::thread(startThread, this);
+  this->events = *(new std::vector<EventData*>());
+  this->thread = new std::thread(startThread, this, &this->closeFlag, &this->exitFlag);
+}
+
+bool EventQueue::isClosed (){
+  if (this->thread == nil)
+    return true;
+  this->closeFlag.lock();
+  bool hasClosed = this->exitFlag == THREAD_EXITED;
+  this->closeFlag.unlock();
+  return hasClosed;
 }
 
 void EventQueue::push(EventData *e){
-	this->lock.lock();
-	this->events.push_back(e);
-	this->lock.unlock();
+  this->lock.lock();
+  this->events.push_back(e);
+  this->lock.unlock();
 }
 void EventQueue::join(){
-	this->thread->join();
+  this->thread->join();
 }
 std::mutex* EventQueue::getLock(){
-	return &this->lock;
+  return &this->lock;
 }
 
-void E2::startThread(EventQueue *e){
-	while(true){
-		e->getLock()->lock();
-		if (!e->events.empty()){
-			// we have a new entry
-			auto event = e->events[0];
-			event->callback(event, event->data);
-			e->lock.lock();
-			e->events.erase(e->events.begin());
-			e->lock.unlock();
-		}
-		e->getLock()->unlock();
-		std::this_thread::sleep_for(std::chrono::nanoseconds(10));
-	}
+EventQueue::~EventQueue(){
+  this->lock.unlock();
+  this->lock.lock();
+  EventData *ptr;
+  auto size = this->events.size();
+  unsigned int index = 0;
+  for(;index < size; index++){
+    if (this->events[index]->data != nil) {
+      delete this->events[index]->data;
+    }
+    delete this->events[index]->name;
+    delete this->events[index];
+  }
+  /* prepare to send signal to the spinlock executor */
+  this->closeFlag.lock();
+  this->exitFlag = 1;
+  this->closeFlag.unlock();
+  /* wait for confirmation */
+  this->closeFlag.lock();
+  /* confirm exit, if not then let process handle it */
+  if (this->exitFlag == THREAD_EXITED){
+    delete this->thread;
+  }
+  this->closeFlag.unlock();
+  this->events.clear();
+  this->lock.unlock();
+}
+/* Spinlock strategy
+*  On a modern multi-core processor CPU utilisation
+*  will always be 0% if there isn't any element
+*  in the queue i.e. thread will be in a pseudo
+*  idle state. */
+
+void E2::startThread(EventQueue *e, std::mutex *closeFlag, int *exitFlag){
+  while(true){
+    e->getLock()->lock();
+    /* add a safe thread exit trigger */
+    closeFlag->lock();
+    if ((*exitFlag) == 1){
+      *exitFlag = THREAD_EXITED;
+      e->getLock()->unlock();
+      break;
+    }
+    closeFlag->unlock();
+
+    if (!e->events.empty()){
+      /* we have a new entry */
+      auto event = e->events[0];
+      event->callback(event, event->data);
+      e->events.erase(e->events.begin());
+    }
+    e->getLock()->unlock();
+    /* for a 2.1Ghz CPU, 2 cycles per nanoseconds */
+    /* also thread sleep are timers and are not true */
+    /* timers in nature */
+    std::this_thread::sleep_for(std::chrono::nanoseconds(1));
+  }
 }

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -78,12 +78,15 @@ namespace E2{
       EventsMap event_map;
       Handle initQueue();
       EventQueue *event_queue;
+      bool _isAlive;
+      std::mutex self;
     public:
       EventMan();
       void Listen(std::string event_name, EventCallbackHandle listener);
       int Trigger(std::string event_name, Handle *data);
       void Exit();
       void Join();
+      bool isAlive();
       ~EventMan();
   };
   // Callback Return type

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -1,55 +1,96 @@
 /*
-	main.hpp
+  main.hpp
 */
 #include <map>
 #include <vector>
 #include <list>
 #include <thread>
+
+#ifndef E2_MAIN_H_
+#define E2_MAIN_H_
+
 #ifndef nil
-	#define nil NULL
+  #define nil NULL
 #endif
 
 #ifndef MAX_THREADS
-	#define MAX_THREADS 5
+  #define MAX_THREADS 5
+#endif
+
+#ifndef THREAD_EXITED
+  #define THREAD_EXITED 0x2
+#endif
+
+/* delete std::string instance of event name */
+#ifndef clear_e2_event_name
+  #define clear_e2_event_name(event) \
+            if (event->name != nil)\
+              delete event->name;
+#endif
+/* delete struct event */
+#ifndef clear_e2_event_obj
+  #define clear_e2_event_obj(event) \
+            if (event != nil)\
+              delete event;
+#endif
+
+/* completley delete the event object */
+#ifndef clear_e2_event
+  #define clear_e2_event(event) \
+          if (event != nil){ \
+            if (event->name != NULL) \
+              delete event->name; \
+            if (event->data != nil) \
+              delete event->data; \
+            delete event; \
+          }
 #endif
 
 namespace E2{
-	typedef void* Handle;
-	typedef Handle (*EventCallbackHandle)(Handle, Handle);
-	typedef std::map<std::string, std::vector<EventCallbackHandle>*> EventsMap;
-	typedef struct edata{
-		std::string *name;
-		EventCallbackHandle callback;
-		std::map<std::string, Handle> *data;
-	}EventData;
-	class EventQueue{
-		private:
-			// std::thread current_proc;
-			std::thread *thread;
-		public:
-			std::vector<EventData*> events;
-			std::mutex lock;
-			EventQueue();
-			void push(EventData* e);
-			std::mutex* getLock();
-			void trigger();
-			void join();
-	};
-	class EventMan{
-		private:
-			EventsMap event_map;
-			Handle initQueue();
-			EventQueue *event_queue;
-		public:
-			EventMan();
-			Handle Listen(Handle event_name, EventCallbackHandle listener);
-			Handle Trigger(Handle event_name, EventData *data);
-			Handle Join();
-	};
-	// Callback Return type
-	typedef struct cr{
-		int type;
-		Handle data;
-	}CallbackReturn;
-	void startThread(EventQueue*);
+  /* a generic void pointer, typecasting is user-domain task */
+  typedef void* Handle;
+  /* signature of our thread function */
+  typedef Handle (*EventCallbackHandle)(Handle, Handle);
+  typedef std::map<std::string, std::vector<EventCallbackHandle>*> EventsMap;
+  typedef struct edata{
+    std::string *name;
+    EventCallbackHandle callback;
+    Handle *data;
+  }EventData;
+  class EventQueue{
+    private:
+      std::thread *thread;
+      std::mutex closeFlag;
+      int exitFlag = 0;
+    public:
+      std::vector<EventData*> events;
+      std::mutex lock;
+      EventQueue();
+      void push(EventData* e);
+      std::mutex* getLock();
+      void trigger();
+      void join();
+      bool isClosed();
+      ~EventQueue();
+  };
+  class EventMan{
+    private:
+      EventsMap event_map;
+      Handle initQueue();
+      EventQueue *event_queue;
+    public:
+      EventMan();
+      void Listen(std::string event_name, EventCallbackHandle listener);
+      int Trigger(std::string event_name, Handle *data);
+      void Exit();
+      void Join();
+      ~EventMan();
+  };
+  // Callback Return type
+  typedef struct cr{
+    int type;
+    Handle data;
+  }CallbackReturn;
+  void startThread(EventQueue*, std::mutex*, int*);
 }
+#endif /* E2_MAIN_H_ */

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -5,21 +5,43 @@ using namespace E2;
 Handle listener(Handle, Handle);
 
 int main(int argc, char* argv[]){
-	E2::EventMan *man; // you can share this instance with other threads
-	man = new E2::EventMan();
-	std::string eName("push");
-	cout << "Pushing Event"<<std::endl;
-	man->Listen(&eName, &listener);
-	man->Trigger(&eName, nil);
-	// call all fs/net and other threads before this
-	// this is the end marker which will block the code
-	man->Join();
-	return 0;
+  E2::EventMan *man; /* you can share this instance with other threads */
+  man = new E2::EventMan();
+  man->Listen("push", &listener);
+  
+  int *data = new int(123);
+  man->Trigger("push", (Handle *)data);
+  man->Trigger("push", nil);
+  man->Trigger("push", nil);
+  /* If event is not present then its a noop() */
+  man->Trigger("lol", nil);
+  // call all fs/net and other threads before this
+  // this is the end marker which will block the code
+  // man->Join();
+  /* Exit method suspends the existing event queue thread
+    flushes all the events and event datas that are queued
+
+    man->Exit();
+    delete man;
+  */
+  return 0;
 }
 
 Handle listener(Handle event, Handle data){
-	E2::EventData *e = (E2::EventData *)event;
-	cout << "Event Triggered" << std::endl;
-	cout << "Event name=> " << *(e->name) << std::endl;
-	return nil;
+  E2::EventData *e = (E2::EventData *)event;
+  cout << "Event Triggered" << std::endl;
+  cout << "Event name=> " << *(e->name) << std::endl;
+  if (data != nil){
+    cout << "The data is an integer: " << *((int*)data) <<endl;
+  }
+  /* 
+    use the helper to clear event data if you want to clear
+    the whole event object with data
+    if not, then just call clear_e2_event_name(e) and clear_e2_event_obj(e)
+    note: Don't call both together
+  */
+  // clear_e2_event_name(e) // delete event->name
+  // clear_e2_event_obj(e) // delete event
+  clear_e2_event(e) // this call deletes data, name and event itself
+  return nil;
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -13,16 +13,17 @@ int main(int argc, char* argv[]){
   man->Trigger("push", (Handle *)data);
   man->Trigger("push", nil);
   man->Trigger("push", nil);
-  /* If event is not present then its a noop() */
+  /* If event is not present then its a noop */
   man->Trigger("lol", nil);
   // call all fs/net and other threads before this
   // this is the end marker which will block the code
-  // man->Join();
+  man->Exit();
+  if (man->isAlive())
+    man->Join();
   /* Exit method suspends the existing event queue thread
     flushes all the events and event datas that are queued
 
     man->Exit();
-    delete man;
   */
   return 0;
 }


### PR DESCRIPTION
Refactor API and fix major issues
* Add destructors for EventQueue and EventMan to clear memory
* Add a controlled event loop exit mechanism
* Add a Exit() method to exit a EventMan and flush all the events
* Add a isAlive() method to check current state of Spinlock queue 
* Add macros to help free event data for listeners 
* Add more info in ReadMe