### PR TITLE
Fix leaks and refactor code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ class FsWrap : public E2::EventHandler {
     }
 };
 int main(int argc, char* argv[]){
-  E2::EventMan *man; // you can share this instance with other threads
-  man = new E2::EventMan();
+  E2::Loop *man; // you can share this instance with other threads
+  man = new E2::Loop();
   /* an object of derived class from EventHandler */
   auto fsObject = new FsWrap();
 
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]){
   man->Trigger("push", data); /* will work now */
   // call all fs/net and other threads before this
   // this is the end marker which will block the code
-  // you can create more EventMan and then wait for all of them
+  // you can create more E2::Loop and then wait for all of them
 
   /* Exit method suspends the existing event queue thread
     flushes all the events and event datas that are queued
@@ -67,23 +67,23 @@ Handle listener(Handle event, Handle data){
 ```
 ## API
 ```c++ 
-bool EventMan.isAlive()
+bool Loop.isAlive()
 ```
 Returns the current state of the event queue, if false than the queue will throw error for any operation
 
 ```c++ 
-bool EventMan.Freeze()
+bool Loop.Freeze()
 ```
 Freezes the event loop, all trigger calls will be ignored
 
 ```c++ 
-bool EventMan.Unfreeze()
+bool Loop.Unfreeze()
 ```
 Unfreeze the event loop, event trigger will resume from the point this function is called
 
 
 ```c++ 
-void EventMan.Push(string name, &handler)
+void Loop.Push(string name, &handler)
 ```
 
 Pushes a new event handler for an event, the handler parameter is a function pointer which can be of the below signature 
@@ -96,39 +96,39 @@ class MyClass:public EventHandler{}
 ```
 
 ```c++
-int EventMan.Trigger(string name, Handle data)
+int Loop.Trigger(string name, Handle data)
 ```
 Triggers all the event listeners of a specific event and passes the data to the handlers, if no such event exists than its a noop(). The function returns the number of listeners triggered
 
 
 ```c++ 
-bool EventMan.Unregister(string event_name)
+bool Loop.Unregister(string event_name)
 ```
 Unregister all the event handlers for a given event_name
 
 
 ```c++ 
-bool EventMan.Unregister(string event_name, function listener)
+bool Loop.Unregister(string event_name, function listener)
 ```
 Unregister a given listener for an event
 
 ```c++ 
-bool EventMan.Unregister(string event_name, EventHandler *instance)
+bool Loop.Unregister(string event_name, EventHandler *instance)
 ```
 Unregister a given EventHandler class instance for a given event
 
 
 ```c++ 
-void EventMan.Join(void)
+void Loop.Join(void)
 ```
 
 Locks the Spinlock thread and waits for its completion.
 
 
 ```c++ 
-void EventMan.Exit(void)
+void Loop.Exit(void)
 ```
-Kills the Spinlock thread. Call ```delete EventMan;``` manually after this to free its memory. You can use this to trigger the end of event loop manually.
+Kills the Spinlock thread. Call ```delete Loop;``` manually after this to free its memory. You can use this to trigger the end of event loop manually.
 
 ### Listeners Helpers
 ```c++

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -31,19 +31,19 @@ class FsWrap : public E2::EventHandler {
 };
 
 int main(int argc, char* argv[]){
-  E2::EventMan *man; /* you can share this instance with other threads */
-  man = new E2::EventMan();
-  man->Listen("push", &listener);
+  E2::Loop *event_loop; /* you can share this instance with other threads */
+  event_loop = new E2::Loop();
+  event_loop->Listen("push", &listener);
   
   Handle* data = (Handle*)new int(123);
-  man->Trigger("push", data);
-  man->Trigger("push", nil);
-  man->Trigger("push", nil);
+  event_loop->Trigger("push", data);
+  event_loop->Trigger("push", nil);
+  event_loop->Trigger("push", nil);
   /* If event is not present then its a noop */
-  man->Trigger("lol", nil);
+  event_loop->Trigger("lol", nil);
   // call all fs/net and other threads before this
   // this is the end marker which will block the code
-  auto FsQueue = new E2::EventMan();
+  auto FsQueue = new E2::Loop();
   auto fsObject = new FsWrap();
   /* todo: Add thread pool */
   /* Till then you can namespace events with inode values */
@@ -56,16 +56,16 @@ int main(int argc, char* argv[]){
   /* Exit method suspends the existing event queue thread
     flushes all the events and event datas that are queued
 
-    man->Exit();
+    event_loop->Exit();
   */
   FsQueue->Unregister("onstart");
   int *sample = new int(0xfAAAAA);
   /* None will be triggered */
   FsQueue->Trigger("onstart", (Handle*)sample);
   FsQueue->Join();
-  man->Exit();
-  if (man->isAlive())
-    man->Join();
+  event_loop->Exit();
+  if (event_loop->isAlive())
+    event_loop->Join();
   return 0;
 }
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1,22 +1,30 @@
 #include <iostream>
 #include "../src/main.hpp"
+#include "../src/console.hpp"
 using namespace std;
 using namespace E2;
+
 Handle listener(Handle, Handle);
 
 class FsWrap : public E2::EventHandler {
-  private:
-    int identifier; /* inode, fd */
   public:
-    FsWrap(){
-      this->identifier = -1; /* init state */
-    }
     void HandleEvent(Handle event, Handle data){
       /* Trigger the events as they appear */
       E2::EventData *instance = (E2::EventData *)event;
+      /* if you are modifying the value of data then use the inbuilt lock */
+      instance->lock.get()->lock();
       /* switch(instance->name) {case "end": break;} */
-      cout << "File Event: " << *(instance->name) << endl;
-      clear_e2_event(instance)
+      if (data != nil) {
+        E2::log("File Event:", instance->name, *(std::string*)data);
+      }
+      int input;
+      E2::log("Input an integer:");
+      console::read(input);
+      E2::log("User input was", input);
+      /* don't forget to release the lock */
+      instance->lock.get()->unlock();
+      /* second parameter is the pointer type of data */
+      clear_e2_event(instance, std::string)
     }
     /*
       Event handlers to be overriden by extending class
@@ -25,9 +33,6 @@ class FsWrap : public E2::EventHandler {
     virtual void onEnd(){}
     virtual void onStart(){}
     virtual void onFlush(){}
-    ~FsWrap(){
-
-    }
 };
 
 int main(int argc, char* argv[]){
@@ -41,42 +46,39 @@ int main(int argc, char* argv[]){
   event_loop->Trigger("push", nil);
   /* If event is not present then its a noop */
   event_loop->Trigger("lol", nil);
-  // call all fs/net and other threads before this
-  // this is the end marker which will block the code
+
   auto FsQueue = new E2::Loop();
+  
   auto fsObject = new FsWrap();
   /* todo: Add thread pool */
   /* a generic to help extend the functionalities of an EventHandler*/
+
+  /* you can directly push an EventHandler in queue through this */
   FsQueue->Trigger<FsWrap*>(fsObject, "onstart", nil);
-  /* you can have functions as well as EventHandler classes */
   /* listening on the same event */
-  FsQueue->Listen<FsWrap*>("onstart", fsObject);
+  FsQueue->Listen<FsWrap*>("onend", fsObject);
+  /* you can have functions as well as EventHandler classes */
   FsQueue->Listen("onstart", &listener);
   FsQueue->Trigger("onstart", nil);
-  /* Exit method suspends the existing event queue thread
-    flushes all the events and event datas that are queued
-
-    event_loop->Exit();
-  */
-  FsQueue->Unregister("onstart");
+  
   int *sample = new int(0xfAAAAA);
-  /* None will be triggered */
   FsQueue->Trigger("onstart", (Handle*)sample);
-  FsQueue->Exit();
-  event_loop->Exit();
-  if (event_loop->isAlive())
-    event_loop->Join();
-  delete FsQueue;
+  std::string *str = new string("Bow down puny species!");
+  FsQueue->Trigger("onend", (Handle*)str);
+  E2::log("Stopping the thread");
+  FsQueue->StopSync();
+  E2::log("Other way of killing the loop is to execute delete");
+  /* clear you class instaces */
   delete event_loop;
+  delete FsQueue;
+  delete fsObject;
   return 0;
 }
 
 Handle listener(Handle event, Handle data){
   E2::EventData *e = (E2::EventData *)event;
-  cout << "Event Triggered" << std::endl;
-  cout << "Event name=> " << *(e->name) << std::endl;
   if (data != nil){
-    cout << "The data is an integer: " << *((int*)data) <<endl;
+    E2::log("The data is an integer: ", *((int*)data));
   }
   /* 
     use the helper to clear event data if you want to clear
@@ -86,6 +88,6 @@ Handle listener(Handle event, Handle data){
   */
   // clear_e2_event_name(e) // delete event->name
   // clear_e2_event_obj(e) // delete event
-  clear_e2_event(e) // this call deletes data, name and event itself
+  clear_e2_event(e, int) // this call deletes data, name and event itself
   return nil;
 }

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -46,11 +46,11 @@ int main(int argc, char* argv[]){
   auto FsQueue = new E2::Loop();
   auto fsObject = new FsWrap();
   /* todo: Add thread pool */
-  /* Till then you can namespace events with inode values */
-  /* or fd in case of net connection */
-  FsQueue->Listen("onstart", fsObject);
+  /* a generic to help extend the functionalities of an EventHandler*/
+  FsQueue->Trigger<FsWrap*>(fsObject, "onstart", nil);
   /* you can have functions as well as EventHandler classes */
   /* listening on the same event */
+  FsQueue->Listen<FsWrap*>("onstart", fsObject);
   FsQueue->Listen("onstart", &listener);
   FsQueue->Trigger("onstart", nil);
   /* Exit method suspends the existing event queue thread
@@ -62,10 +62,12 @@ int main(int argc, char* argv[]){
   int *sample = new int(0xfAAAAA);
   /* None will be triggered */
   FsQueue->Trigger("onstart", (Handle*)sample);
-  FsQueue->Join();
+  FsQueue->Exit();
   event_loop->Exit();
   if (event_loop->isAlive())
     event_loop->Join();
+  delete FsQueue;
+  delete event_loop;
   return 0;
 }
 

--- a/maketest.sh
+++ b/maketest.sh
@@ -1,3 +1,19 @@
 #!/bin/bash
+compiler=$(which clang++)
+if [[ $? != 0 ]]
+  then
+  echo "Need clang++ with c++11 std support, exiting"
+  exit 2
+fi
 
-clang++ -std=c++11 -fsanitize=address -fno-omit-frame-pointer -g src/main.cpp example/example.cpp -o test-out
+compilerOps='-std=c++11 -pthread'
+debugFlags=""
+if [[ $# == 1 ]]
+  then
+  if [[ $1 == "-debug=true" ]]
+    then
+    debugFlags='-g -fsanitize=address -fno-omit-frame-pointer'
+  fi
+fi
+
+clang++ ${compilerOps} ${debugFlags} src/console.cpp src/main.cpp example/example.cpp -o test-out

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -1,0 +1,21 @@
+/*
+  console.cpp
+  This is a utility for sync stdio ops, helps make your
+  couts better.
+*/
+#include <iostream>
+#include "main.hpp"
+#include "console.hpp"
+
+Handle E2::__console_printer(Handle event, Handle data){
+  auto eInstance = (E2::EventData*) event;
+  std::cout << *((std::string*)data) << std::endl;
+  clear_e2_event(eInstance, std::string)
+  return nil;
+}
+
+/* assign memory to static members */
+E2::Loop console::loop;
+std::mutex console::lock;
+std::string console::buffer;
+int console::num = 0;

--- a/src/console.hpp
+++ b/src/console.hpp
@@ -1,0 +1,77 @@
+/*
+  Console Lib v0.1
+  Console utility for systematic stdio operations
+  throughout the use of E2 library
+*/
+#include <iostream>
+#include <string>
+#include <sstream>
+
+#ifndef E2_CONSOLE_H_
+#define E2_CONSOLE_H_
+#include "main.hpp"
+using namespace E2;
+
+namespace E2{
+  Handle __console_printer(Handle event, Handle data);
+  class console {
+    private:
+      static std::mutex lock;
+      static std::string buffer;
+      static int num;
+      static E2::Loop loop;  // feed me!
+    public:
+      static std::mutex* getLock(){
+        return &lock;
+      }
+      template <typename... Args>
+        static void log(Args&&... args){
+          console::prepare(std::forward<Args>(args)...);
+      }
+      /* this function will work in sync to avoid race conditions */
+      template <typename... Args>
+        static void read(Args&&... args){
+          lock.lock();
+          console::prepareForRead(std::forward<Args>(args)...);
+          lock.unlock();
+      }
+      template <typename Arg>
+        static void prepare(Arg&& args){
+          std::stringstream stream;
+          stream << std::forward<Arg>(args);
+          buffer += (num != 0 ? " ": "") + stream.str();
+          /* donot kill the original string data */
+          std::string *buffer_ptr = new std::string(buffer);
+          loop.Trigger(&__console_printer, "stdout", (Handle*)buffer_ptr);
+          buffer = "";
+          num = 0;
+      }
+      template <typename T, typename... Args>
+        static void prepare(T&& val, Args&&... args){
+          std::stringstream stream;
+          num = 1;
+          stream << std::forward<T>(val);
+          buffer += stream.str();
+          console::prepare(std::forward<Args>(args)...);
+      }
+      
+      template <typename Arg>
+        static void prepareForRead(Arg&& args){
+          std::cin >> std::forward<Arg>(args);
+      }
+      
+      template <typename T, typename... Args> 
+        static void prepareForRead(T&& val, Args&&... args){
+          std::cin >> std::forward<T>(val);
+          console::prepareForRead(std::forward<Args>(args)...);
+    }
+  };
+
+  template <typename... Args> static void log(Args&&... args);
+  template <typename... Args> static void log(Args&&... args){
+    console::getLock()->lock();
+    console::log(std::forward<Args>(args)...);
+    console::getLock()->unlock();
+  }
+}
+#endif //E2_CONSOLE_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,21 +9,21 @@
 using namespace E2;
 using namespace std;
 
-EventMan::EventMan(){
+Loop::Loop(){
   this->initQueue();
 }
 
-Handle EventMan::initQueue(){
+Handle Loop::initQueue(){
   this->event_queue = new EventQueue();
   this->_isAlive = true;
   return nil;
 }
 
-void EventMan::Join(){
+void Loop::Join(){
   this->event_queue->join();
 }
 
-void EventMan::Listen(std::string event_name, EventCallbackHandle listener){
+void Loop::Listen(std::string event_name, EventCallbackHandle listener){
   this->self.lock();
   auto hasEvent = this->event_map[event_name];
   if (hasEvent == nil){
@@ -35,7 +35,7 @@ void EventMan::Listen(std::string event_name, EventCallbackHandle listener){
   this->self.unlock();
 }
 
-void EventMan::Listen(std::string event_name, E2::EventHandler *instance){
+void Loop::Listen(std::string event_name, E2::EventHandler *instance){
   this->self.lock();
   auto hasEvent = this->instance_map[event_name];
   if (hasEvent == nil){
@@ -47,7 +47,7 @@ void EventMan::Listen(std::string event_name, E2::EventHandler *instance){
   this->self.unlock();
 }
 
-int EventMan::Trigger(std::string event_name, Handle *data){
+int Loop::Trigger(std::string event_name, Handle *data){
   /* do not trigger if exited */
   this->self.lock();
   if (!this->_isAlive){
@@ -65,7 +65,7 @@ int EventMan::Trigger(std::string event_name, Handle *data){
   return count;
 }
 
-void EventMan::Unregister(std::string event_name){
+void Loop::Unregister(std::string event_name){
   this->self.lock();
   ClearEvent(event, event_name)
   ClearEvent(instance, event_name)
@@ -73,21 +73,21 @@ void EventMan::Unregister(std::string event_name){
 }
 
 /* Unregister from events_map of static functions */
-void EventMan::Unregister(std::string event_name, EventCallbackHandle handle){
+void Loop::Unregister(std::string event_name, EventCallbackHandle handle){
   this->self.lock();
   ClearListener(event, event_name, handle)
   this->self.unlock();
 }
 
 /* Unregister from instance_map */
-void EventMan::Unregister(std::string event_name, EventHandler* handle){
+void Loop::Unregister(std::string event_name, EventHandler* handle){
   this->self.lock();
   ClearListener(instance, event_name, handle)
   this->self.unlock();
 }
 
 /* Unregister all the listeners */
-void EventMan::UnregisterAll(){
+void Loop::UnregisterAll(){
   this->self.lock();
   auto event_itr = this->event_map.begin();
   for(;event_itr != this->event_map.end(); ++event_itr){
@@ -101,7 +101,7 @@ void EventMan::UnregisterAll(){
 }
 
 /* Blocks any new event trigger */
-void EventMan::Freeze(){
+void Loop::Freeze(){
   this->self.lock();
   if (this->_isAlive == true){
     this->_isAlive = false;
@@ -110,7 +110,7 @@ void EventMan::Freeze(){
 }
 
 /* Unfreeze a frozen event queue */
-bool EventMan::Unfreeze(){
+bool Loop::Unfreeze(){
   bool done = false;
   this->self.lock();
   if (this->event_queue->isClosed()){
@@ -121,14 +121,14 @@ bool EventMan::Unfreeze(){
   return done;
 }
 
-bool EventMan::isAlive(){
+bool Loop::isAlive(){
   this->self.lock();
   bool _isAlive = this->_isAlive;
   this->self.unlock();
   return _isAlive;
 }
 
-void EventMan::Exit(){
+void Loop::Exit(){
   this->self.lock();
   this->_isAlive = false;
   if (!this->event_queue->isClosed()){
@@ -138,7 +138,7 @@ void EventMan::Exit(){
   this->self.unlock();
 }
 
-EventMan::~EventMan(){
+Loop::~Loop(){
   if (this->event_queue != nil){
     delete this->event_queue;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <chrono>
 #include "main.hpp"
+
 using namespace E2;
 using namespace std;
 
@@ -26,15 +27,25 @@ void Loop::Join(){
 
 void Loop::Listen(std::string event_name, EventCallbackHandle listener){
   this->self.lock();
-  ListenCodeStub(event, event_name, EventCallbackHandle)
+  auto hasEvent = this->event_map[event_name]; 
+  if (hasEvent == nil){
+    /* event doesn't exists */
+    std::vector<EventCallbackHandle>
+      *vec = new std::vector<EventCallbackHandle>(); 
+    this->event_map[event_name] = vec;         
+  }
   this->event_map[event_name]->push_back(listener);
   this->self.unlock();
 }
 
 void Loop::Listen(std::string event_name, E2::EventHandler *instance){
   this->self.lock();
-  ListenCodeStub(instance, event_name, EventHandler*)
-  this->instance_map[event_name]->push_back(instance);
+  if (!this->_isAlive){
+    this->self.unlock();
+    return;
+  }
+  ListenCodeStub(instance, event_name, EventHandler)
+  this->instance_map[event_name]->push_back(std::unique_ptr<E2::EventHandler>(instance));
   this->self.unlock();
 }
 
@@ -49,9 +60,15 @@ int Loop::Trigger(std::string event_name, Handle *data){
   
   int count = 0;
   /* trigger all the function handler */
-  TriggerListeners(event, event_name, callback)
+  bool isInstance = false;
+  std::shared_ptr<EventDataWrap> ptr = std::make_shared<EventDataWrap>();
+  std::shared_ptr<std::mutex> shared_lock = std::make_shared<std::mutex>();
+  TriggerListeners(event, event_name, callback, el, el)
   /* trigger all instance handler */
-  TriggerListeners(instance, event_name, instance)
+  isInstance = true;
+  TriggerListeners(instance, event_name, instance, &el, (el.get()))
+  ptr.reset();
+  shared_lock.reset();
   this->self.unlock();
   return count;
 }
@@ -66,7 +83,13 @@ void Loop::Unregister(std::string event_name){
 /* Unregister from events_map of static functions */
 void Loop::Unregister(std::string event_name, EventCallbackHandle handle){
   this->self.lock();
-  ClearListener(event, event_name, handle)
+  if (this->event_map[event_name] != nil) {      
+    auto _list = this->event_map[event_name];    
+    _list->erase(std::remove(_list->begin(),      
+       _list->end(), handle), _list->end());     
+  } else {
+    this->event_map.erase(event_name);
+  }
   this->self.unlock();
 }
 
@@ -119,35 +142,71 @@ bool Loop::isAlive(){
   return _isAlive;
 }
 
-void Loop::Exit(){
+void Loop::Stop(){
   this->self.lock();
   this->_isAlive = false;
-  if (!this->event_queue->isClosed()){
-    delete this->event_queue;
-    this->event_queue = nil;
-  }
+  this->event_queue->Stop();
+  this->self.unlock();
+}
+
+void Loop::StopSync(){
+  this->self.lock();
+  this->_isAlive = false;
+  this->event_queue->Stop();
+  this->event_queue->join();
   this->self.unlock();
 }
 
 Loop::~Loop(){
   if (this->event_queue != nil){
-    delete this->event_queue;
+    this->event_queue->Stop();
+    this->event_queue->join();
   }
   if (this->event_map.empty() == false){
     auto iterator = this->event_map.begin();
     do {
+      iterator->second->clear();
       delete iterator->second;
       ++iterator;
     } while(iterator != this->event_map.end());
     this->event_map.clear();
   }
+  if (this->instance_map.empty() == false){
+    auto iterator = this->instance_map.begin();
+    do {
+      auto vector_iterator = iterator->second->begin();
+      
+      do {
+        vector_iterator->release();
+        ++vector_iterator;
+      } while(vector_iterator != iterator->second->end());
+
+      iterator->second->clear();
+      delete iterator->second;
+      ++iterator;
+    } while(iterator != this->instance_map.end());
+
+    this->instance_map.clear();
+  }
+  delete this->event_queue;
 }
 
 EventQueue::EventQueue(){
-  this->events = *(new std::vector<EventData*>());
-  this->thread = new std::thread(startThread, this, &this->closeFlag, &this->exitFlag);
+  this->exitFlag = 0;
+  this->events = new std::vector<EventData*>();
+  this->thread = new std::thread(startThread, this, &this->closeFlag);
 }
 
+void EventQueue::Stop(){
+  this->setExitFlag(THREAD_EXITED);
+}
+
+int EventQueue::getExitFlag(){
+  return this->exitFlag;
+}
+void EventQueue::setExitFlag(int flag){
+  this->exitFlag = flag;
+}
 bool EventQueue::isClosed (){
   if (this->thread == nil)
     return true;
@@ -159,44 +218,45 @@ bool EventQueue::isClosed (){
 
 void EventQueue::push(EventData *e){
   this->lock.lock();
-  this->events.push_back(e);
+  this->events->push_back(e);
   this->lock.unlock();
 }
 
 void EventQueue::join(){
-  this->thread->join();
+  if (this->thread->joinable())
+    this->thread->join();
 }
 std::mutex* EventQueue::getLock(){
   return &this->lock;
 }
 
 EventQueue::~EventQueue(){
-  if (this->isClosed()){
-    return;
+  if (this->getExitFlag() != THREAD_EXITED){
+    this->closeFlag.lock();
+    this->setExitFlag(THREAD_EXITED);
+    this->closeFlag.unlock();
   }
+  if (this->thread->joinable())
+    this->thread->join();
   this->lock.lock();
-  EventData *ptr;
-  auto size = this->events.size();
-  unsigned int index = 0;
-  for(;index < size; index++){
-    if (this->events[index]->data != nil) {
-      delete this->events[index]->data;
-    }
-    delete this->events[index]->name;
-    delete this->events[index];
-  }
-  /* prepare to send signal to the spinlock executor */
   this->closeFlag.lock();
-  this->exitFlag = 1;
-  this->closeFlag.unlock();
-  /* wait for confirmation */
-  this->closeFlag.lock();
-  /* confirm exit, if not then let process handle it */
-  if (this->exitFlag == THREAD_EXITED){
-    delete this->thread;
+  auto size = this->events->size();
+  auto index = this->events->begin();
+  if (size > 0){
+    do {
+      if ( (*index)->data != nullptr)
+        delete (*index)->data;
+
+      if (*index != nil) {
+        delete *index;
+      }
+      ++index;
+    } while(index != this->events->end());
   }
   this->closeFlag.unlock();
-  this->events.clear();
+  this->events->clear();
+  delete this->events;
+  delete this->thread;
   this->lock.unlock();
 }
 /* Spinlock strategy
@@ -205,35 +265,43 @@ EventQueue::~EventQueue(){
 *  in the queue i.e. thread will be in a pseudo
 *  idle state. */
 
-void E2::startThread(EventQueue *e, std::mutex *closeFlag, int *exitFlag){
+void E2::startThread(EventQueue *e, std::mutex *closeFlag){
+  int eFlag = 0;
   while(true){
-    e->getLock()->lock();
     /* add a safe thread exit trigger */
-    closeFlag->lock();
-    if ((*exitFlag) == 1){
-      *exitFlag = THREAD_EXITED;
-      e->getLock()->unlock();
-      closeFlag->unlock();
-      break;
+    if(closeFlag->try_lock()){
+      if (e->getExitFlag() == THREAD_EXITED){
+        if (e->events->empty()){
+          eFlag = THREAD_EXITED;
+          break;
+        }
+      }
+    }
+    if(e->getLock()->try_lock()){
+      if (!e->events->empty()){
+        /* we have a new entry */
+        auto event = (*(e->events))[0];
+        /* a function handler */
+        if (event->instance == nil){
+          event->callback(event, event->data);
+        } else {
+          /* a EventHandler class handler */
+          event->instance->HandleEvent(event, event->data);
+        }
+        e->events->erase(e->events->begin());
+      }
     }
     closeFlag->unlock();
-
-    if (!e->events.empty()){
-      /* we have a new entry */
-      auto event = e->events[0];
-      /* a function handler */
-      if (event->instance == nil){
-        event->callback(event, event->data);
-      } else {
-        /* a EventHandler class handler */
-        event->instance->HandleEvent(event, event->data);
-      }
-      e->events.erase(e->events.begin());
-    }
-    e->getLock()->unlock();
+    if (eFlag != THREAD_EXITED)
+      e->getLock()->unlock();
     /* for a 2.1Ghz CPU, 2 cycles per nanoseconds */
     /* also thread sleep are timers and are not true */
     /* timers in nature */
     std::this_thread::sleep_for(std::chrono::nanoseconds(1));
   }
+  if (eFlag == THREAD_EXITED){
+    closeFlag->unlock();
+    e->getLock()->unlock();
+  }
+  return;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <thread>
+#include <algorithm>
 #include <chrono>
 #include "main.hpp"
 using namespace E2;
@@ -25,24 +26,14 @@ void Loop::Join(){
 
 void Loop::Listen(std::string event_name, EventCallbackHandle listener){
   this->self.lock();
-  auto hasEvent = this->event_map[event_name];
-  if (hasEvent == nil){
-    /* event doesn't exists */
-    std::vector<EventCallbackHandle> *vec = new std::vector<EventCallbackHandle>();
-    this->event_map[event_name] = vec;
-  }
+  ListenCodeStub(event, event_name, EventCallbackHandle)
   this->event_map[event_name]->push_back(listener);
   this->self.unlock();
 }
 
 void Loop::Listen(std::string event_name, E2::EventHandler *instance){
   this->self.lock();
-  auto hasEvent = this->instance_map[event_name];
-  if (hasEvent == nil){
-    /* event doesn't exists */
-    std::vector<E2::EventHandler*> *vec = new std::vector<E2::EventHandler*>();
-    this->instance_map[event_name] = vec;
-  }
+  ListenCodeStub(instance, event_name, EventHandler*)
   this->instance_map[event_name]->push_back(instance);
   this->self.unlock();
 }
@@ -143,6 +134,11 @@ Loop::~Loop(){
     delete this->event_queue;
   }
   if (this->event_map.empty() == false){
+    auto iterator = this->event_map.begin();
+    do {
+      delete iterator->second;
+      ++iterator;
+    } while(iterator != this->event_map.end());
     this->event_map.clear();
   }
 }

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -6,8 +6,8 @@
 #include <list>
 #include <thread>
 
-#ifndef E2_MAIN_H_
-#define E2_MAIN_H_
+#ifndef E2_LOOP_H_
+#define E2_LOOP_H_
 
 #ifndef nil
   #define nil NULL
@@ -131,7 +131,7 @@ namespace E2{
       bool isClosed();
       ~EventQueue();
   };
-  class EventMan{
+  class Loop{
     private:
       EventsMap event_map;
       HandlerInstance instance_map;
@@ -140,7 +140,7 @@ namespace E2{
       bool _isAlive;
       std::mutex self;
     public:
-      EventMan();
+      Loop();
       void Listen(std::string event_name, EventCallbackHandle listener);
       void Listen(std::string event_name, EventHandler *instance);
       int Trigger(std::string event_name, Handle *data);
@@ -153,7 +153,7 @@ namespace E2{
       void Freeze();
       bool Unfreeze();
       bool isAlive();
-      ~EventMan();
+      ~Loop();
   };
   // Callback Return type
   typedef struct cr{
@@ -162,4 +162,4 @@ namespace E2{
   }CallbackReturn;
   void startThread(EventQueue*, std::mutex*, int*);
 }
-#endif /* E2_MAIN_H_ */
+#endif /* E2_LOOP_H_ */

--- a/src/stub.hpp
+++ b/src/stub.hpp
@@ -5,48 +5,46 @@
 #ifndef E2_STUB_H_
 #define E2_STUB_H_
 
-/* delete std::string instance of event name */
-#define clear_e2_event_name(event) \
-  if (event->name != nil)          \
-    delete event->name;
-
-/* delete struct event */
+#define efree(obj)    \
+  if (obj != nullptr) \
+    delete obj;
+/* delete struct event and data too if we are the last */
+/* to hold the shared_ptr */
 #define clear_e2_event_obj(event) \
   if (event != nil)               \
     delete event;
 
 /* completley delete the event object */
-#define clear_e2_event(event)  \
+#define clear_e2_event(event, data_type)  \
   if (event != nil){           \
-    if (event->name != NULL)   \
-      delete event->name;      \
-    if (event->data != nil)    \
-      delete event->data;      \
+    if (event->ptr.use_count() == 1 && event->data != nil)  \
+      delete (data_type *)event->data;  \
     delete event;              \
   }
 
 
 #define ReturnIfNoListeners(type1, type2, name)                           \
-  if (this->type1##_map[name] == nil && this->type2##_map[name] == nil) { \
-    this->type1##_map.erase(name);                                        \
-    this->type2##_map.erase(name);                                        \
+  auto type1##iterator = this->type1##_map.find(name);                    \
+  auto type2##iterator = this->type2##_map.find(name);                    \
+  if ( type1##iterator != this->type1##_map.end() &&                      \
+   type2##iterator != this->type2##_map.end()) {                          \
     this->self.unlock();                                                  \
+    delete data;                                                          \
     return 0;                                                             \
   }
 
-#define TriggerListeners(type, event_name, key)       \
-  if (this->type##_map[event_name] != nil) {          \
-    auto listeners = *(this->type##_map[event_name]); \
-    for(auto el : listeners){                         \
-      auto e = new EventData();                       \
-      e->name = new std::string(event_name);          \
-      e->key = el;                                    \
-      e->data = data;                                 \
-      this->event_queue->push(e);                     \
-      ++count;                                        \
-    }                                                 \
-  } else {                                            \
-    this->type##_map.erase(event_name);               \
+#define TriggerListeners(type, event_name, key, itr_type, ret_type)  \
+    if (type##iterator != this->type##_map.end()) {                  \
+      for(auto itr_type : *(type##iterator->second)){                \
+        auto e = new EventData();                                    \
+        e->name = event_name;                                        \
+        e->key = ret_type;                                           \
+        e->ptr = ptr;                                                \
+        e->lock = shared_lock;                                       \
+        e->data = data;                                              \
+        this->event_queue->push(e);                                  \
+        ++count;                                                     \
+      }                                                              \
   }
 
 #define ClearEvent(type, event_name)           \
@@ -56,21 +54,28 @@
   }                                            \
   this->type##_map.erase(event_name);
 
-#define ClearListener(type, event_name, handler)  \
-  if (this->type##_map[event_name] != nil) {      \
-    auto _list = this->type##_map[event_name];    \
-    _list->erase(std::remove(_list->begin(),      \
-       _list->end(), handler), _list->end());     \
-  } else {                                        \
-    this->type##_map.erase(event_name);           \
+#define ClearListener(type, event_name, handler)          \
+  if (this->type##_map[event_name] != nil) {              \
+    auto _list = this->type##_map[event_name];            \
+    auto itr = std::find_if(_list->begin(), _list->end(), \
+     [&](std::unique_ptr<EventHandler> &ptr){             \
+      return ptr.get() == handler;                        \
+    });                                                   \
+    while (itr != _list->end()){                          \
+      itr->release();                                     \
+      _list->erase(itr);                                  \
+      ++itr;                                              \
+    }                                                     \
+  } else {                                                \
+    this->type##_map.erase(event_name);                   \
   }
 
 #define ListenCodeStub(map_name, event_name, cast)  \
   auto hasEvent = this->map_name##_map[event_name]; \
   if (hasEvent == nil){                             \
     /* event doesn't exists */                      \
-    std::vector<E2:: cast>                          \
-      *vec = new std::vector<E2:: cast>();          \
+    std::vector<std::unique_ptr<E2:: cast>>                 \
+      *vec = new std::vector<std::unique_ptr<E2:: cast>>(); \
     this->map_name##_map[event_name] = vec;         \
   }
 

--- a/src/stub.hpp
+++ b/src/stub.hpp
@@ -1,0 +1,77 @@
+/*
+  E2 lib's code stubs to avoid duplicating code
+*/
+
+#ifndef E2_STUB_H_
+#define E2_STUB_H_
+
+/* delete std::string instance of event name */
+#define clear_e2_event_name(event) \
+  if (event->name != nil)          \
+    delete event->name;
+
+/* delete struct event */
+#define clear_e2_event_obj(event) \
+  if (event != nil)               \
+    delete event;
+
+/* completley delete the event object */
+#define clear_e2_event(event)  \
+  if (event != nil){           \
+    if (event->name != NULL)   \
+      delete event->name;      \
+    if (event->data != nil)    \
+      delete event->data;      \
+    delete event;              \
+  }
+
+
+#define ReturnIfNoListeners(type1, type2, name)                           \
+  if (this->type1##_map[name] == nil && this->type2##_map[name] == nil) { \
+    this->type1##_map.erase(name);                                        \
+    this->type2##_map.erase(name);                                        \
+    this->self.unlock();                                                  \
+    return 0;                                                             \
+  }
+
+#define TriggerListeners(type, event_name, key)       \
+  if (this->type##_map[event_name] != nil) {          \
+    auto listeners = *(this->type##_map[event_name]); \
+    for(auto el : listeners){                         \
+      auto e = new EventData();                       \
+      e->name = new std::string(event_name);          \
+      e->key = el;                                    \
+      e->data = data;                                 \
+      this->event_queue->push(e);                     \
+      ++count;                                        \
+    }                                                 \
+  } else {                                            \
+    this->type##_map.erase(event_name);               \
+  }
+
+#define ClearEvent(type, event_name)           \
+  if (this->type##_map[event_name] != nil) {   \
+    auto _list = this->type##_map[event_name]; \
+    _list->clear();                            \
+  }                                            \
+  this->type##_map.erase(event_name);
+
+#define ClearListener(type, event_name, handler)  \
+  if (this->type##_map[event_name] != nil) {      \
+    auto _list = this->type##_map[event_name];    \
+    _list->erase(std::remove(_list->begin(),      \
+       _list->end(), handler), _list->end());     \
+  } else {                                        \
+    this->type##_map.erase(event_name);           \
+  }
+
+#define ListenCodeStub(map_name, event_name, cast)  \
+  auto hasEvent = this->map_name##_map[event_name]; \
+  if (hasEvent == nil){                             \
+    /* event doesn't exists */                      \
+    std::vector<E2:: cast>                          \
+      *vec = new std::vector<E2:: cast>();          \
+    this->map_name##_map[event_name] = vec;         \
+  }
+
+#endif // end E2_STUB_H_


### PR DESCRIPTION
So there were various points where we were leaking memory.
1. ```Handler data```
- The data passed to the loops was of ```void*``` type hence a simple ```delete``` on it won't work it would require a datatype of it
- The data passed through ```main() thread#0``` to the loops needs to cleared in ```thread#0``` but that can be done after being sure that no one else is going to consume it, for the sanity any to reduce complexity the data clearing part is now been moved and left to the loop handlers themselves
___What this means?___
Now the data passed to the listeners should be a copy of original data iff you are reusing it after passing it to the trigger, the data will be cleared automatically by the last Handler.

2. Instance Listeners
- Instance listeners are now saved as a ```unqiue_ptr``` rather than being just a simple pointer

___What this means?___
This addition adds a complexity layer to the functionalities of adding instance as listeners, an Unregister call will delete the instance object and that can cause the system to fall in an undefined state if that object is in use. ___Always make sure that the object is no longer in user before calling Unregister___

3. [meta] Stdio Operations
- This is a meta feature added to make stdio more easy, instead of using conventional ```cout``` now users can use ```E2::log()``` to print anything on stdio, to read data users can use ```console::read(variable)```. Both the operations are thread safe.